### PR TITLE
Inject profile repository and simplify MainScreen

### DIFF
--- a/app/src/main/java/dev/mexware/stresswatch/data/ProfilesRepository.kt
+++ b/app/src/main/java/dev/mexware/stresswatch/data/ProfilesRepository.kt
@@ -8,5 +8,6 @@ interface ProfilesRepository {
     fun selectProfile(index: Int)
     fun currentHomeUiState(): HomeUiState
     fun sensorData(type: SensorType): SensorDetailUiState
+    fun login(email: String, password: String): Boolean
 }
 

--- a/app/src/main/java/dev/mexware/stresswatch/data/ProfilesRepository.kt
+++ b/app/src/main/java/dev/mexware/stresswatch/data/ProfilesRepository.kt
@@ -1,0 +1,12 @@
+package dev.mexware.stresswatch.data
+
+import dev.mexware.stresswatch.feature.home.model.events.HomeUiState
+import dev.mexware.stresswatch.feature.sensors.model.SensorType
+import dev.mexware.stresswatch.feature.sensors.model.events.SensorDetailUiState
+
+interface ProfilesRepository {
+    fun selectProfile(index: Int)
+    fun currentHomeUiState(): HomeUiState
+    fun sensorData(type: SensorType): SensorDetailUiState
+}
+

--- a/app/src/main/java/dev/mexware/stresswatch/data/SampleProfilesRepository.kt
+++ b/app/src/main/java/dev/mexware/stresswatch/data/SampleProfilesRepository.kt
@@ -1,0 +1,217 @@
+package dev.mexware.stresswatch.data
+
+import dev.mexware.stresswatch.feature.auth.model.Gender
+import dev.mexware.stresswatch.feature.home.model.events.HomeUiState
+import dev.mexware.stresswatch.feature.sensors.model.SensorType
+import dev.mexware.stresswatch.feature.sensors.model.events.SensorDetailUiState
+import dev.mexware.stresswatch.feature.sensors.model.timeseries.Summary
+import dev.mexware.stresswatch.feature.sensors.model.timeseries.TimePoint
+
+object SampleProfilesRepository : ProfilesRepository {
+
+    data class Profile(
+        val home: HomeUiState,
+        val sensors: Map<SensorType, SensorDetailUiState>
+    )
+
+    private val profiles = listOf(
+        Profile(
+            home = HomeUiState(
+                name = "Ana",
+                gender = Gender.FEMALE,
+                birthDate = "12/05/1995",
+                country = "México",
+                avatarId = 1
+            ),
+            sensors = mapOf(
+                SensorType.STRESS to SensorDetailUiState(
+                    type = SensorType.STRESS,
+                    points = listOf(
+                        TimePoint("L", 30f),
+                        TimePoint("M", 40f),
+                        TimePoint("X", 35f),
+                        TimePoint("J", 50f),
+                        TimePoint("V", 45f),
+                        TimePoint("S", 60f),
+                        TimePoint("D", 55f)
+                    ),
+                    summary = Summary(
+                        totalLabel = "Estrés actual",
+                        totalValue = "55%",
+                        note = "Estrés moderado"
+                    )
+                ),
+                SensorType.SLEEP to SensorDetailUiState(
+                    type = SensorType.SLEEP,
+                    points = listOf(
+                        TimePoint("L", 80f),
+                        TimePoint("M", 82f),
+                        TimePoint("X", 78f),
+                        TimePoint("J", 75f),
+                        TimePoint("V", 90f),
+                        TimePoint("S", 85f),
+                        TimePoint("D", 88f)
+                    ),
+                    summary = Summary(
+                        totalLabel = "Sueño total",
+                        totalValue = "88%",
+                        note = "Buen descanso esta semana"
+                    )
+                ),
+                SensorType.MOOD to SensorDetailUiState(
+                    type = SensorType.MOOD,
+                    points = listOf(
+                        TimePoint("L", 70f),
+                        TimePoint("M", 68f),
+                        TimePoint("X", 72f),
+                        TimePoint("J", 75f),
+                        TimePoint("V", 65f),
+                        TimePoint("S", 60f),
+                        TimePoint("D", 70f)
+                    ),
+                    summary = Summary(
+                        totalLabel = "Ánimo actual",
+                        totalValue = "70%",
+                        note = "Mejor que la semana pasada"
+                    )
+                )
+            )
+        ),
+        Profile(
+            home = HomeUiState(
+                name = "Luis",
+                gender = Gender.MALE,
+                birthDate = "03/11/1990",
+                country = "España",
+                avatarId = 2
+            ),
+            sensors = mapOf(
+                SensorType.STRESS to SensorDetailUiState(
+                    type = SensorType.STRESS,
+                    points = listOf(
+                        TimePoint("L", 60f),
+                        TimePoint("M", 62f),
+                        TimePoint("X", 58f),
+                        TimePoint("J", 65f),
+                        TimePoint("V", 70f),
+                        TimePoint("S", 75f),
+                        TimePoint("D", 72f)
+                    ),
+                    summary = Summary(
+                        totalLabel = "Estrés actual",
+                        totalValue = "72%",
+                        note = "Estrés alto"
+                    )
+                ),
+                SensorType.SLEEP to SensorDetailUiState(
+                    type = SensorType.SLEEP,
+                    points = listOf(
+                        TimePoint("L", 55f),
+                        TimePoint("M", 60f),
+                        TimePoint("X", 50f),
+                        TimePoint("J", 45f),
+                        TimePoint("V", 65f),
+                        TimePoint("S", 70f),
+                        TimePoint("D", 60f)
+                    ),
+                    summary = Summary(
+                        totalLabel = "Sueño total",
+                        totalValue = "60%",
+                        note = "Intenta mejorar tu rutina nocturna"
+                    )
+                ),
+                SensorType.MOOD to SensorDetailUiState(
+                    type = SensorType.MOOD,
+                    points = listOf(
+                        TimePoint("L", 40f),
+                        TimePoint("M", 45f),
+                        TimePoint("X", 50f),
+                        TimePoint("J", 48f),
+                        TimePoint("V", 52f),
+                        TimePoint("S", 55f),
+                        TimePoint("D", 50f)
+                    ),
+                    summary = Summary(
+                        totalLabel = "Ánimo actual",
+                        totalValue = "50%",
+                        note = "Podrías intentar una sesión de respiración"
+                    )
+                )
+            )
+        ),
+        Profile(
+            home = HomeUiState(
+                name = "Carla",
+                gender = Gender.FEMALE,
+                birthDate = "22/08/1988",
+                country = "Argentina",
+                avatarId = 3
+            ),
+            sensors = mapOf(
+                SensorType.STRESS to SensorDetailUiState(
+                    type = SensorType.STRESS,
+                    points = listOf(
+                        TimePoint("L", 20f),
+                        TimePoint("M", 25f),
+                        TimePoint("X", 30f),
+                        TimePoint("J", 28f),
+                        TimePoint("V", 22f),
+                        TimePoint("S", 18f),
+                        TimePoint("D", 20f)
+                    ),
+                    summary = Summary(
+                        totalLabel = "Estrés actual",
+                        totalValue = "20%",
+                        note = "Estrés bajo"
+                    )
+                ),
+                SensorType.SLEEP to SensorDetailUiState(
+                    type = SensorType.SLEEP,
+                    points = listOf(
+                        TimePoint("L", 90f),
+                        TimePoint("M", 92f),
+                        TimePoint("X", 88f),
+                        TimePoint("J", 95f),
+                        TimePoint("V", 94f),
+                        TimePoint("S", 96f),
+                        TimePoint("D", 93f)
+                    ),
+                    summary = Summary(
+                        totalLabel = "Sueño total",
+                        totalValue = "93%",
+                        note = "Buen descanso esta semana"
+                    )
+                ),
+                SensorType.MOOD to SensorDetailUiState(
+                    type = SensorType.MOOD,
+                    points = listOf(
+                        TimePoint("L", 85f),
+                        TimePoint("M", 82f),
+                        TimePoint("X", 80f),
+                        TimePoint("J", 88f),
+                        TimePoint("V", 86f),
+                        TimePoint("S", 84f),
+                        TimePoint("D", 87f)
+                    ),
+                    summary = Summary(
+                        totalLabel = "Ánimo actual",
+                        totalValue = "87%",
+                        note = "Mejor que la semana pasada"
+                    )
+                )
+            )
+        )
+    )
+
+    private var currentIndex = 0
+
+    override fun selectProfile(index: Int) {
+        currentIndex = index.coerceIn(profiles.indices)
+    }
+
+    override fun currentHomeUiState(): HomeUiState = profiles[currentIndex].home
+
+    override fun sensorData(type: SensorType): SensorDetailUiState =
+        profiles[currentIndex].sensors[type] ?: SensorDetailUiState(type)
+}
+

--- a/app/src/main/java/dev/mexware/stresswatch/data/SampleProfilesRepository.kt
+++ b/app/src/main/java/dev/mexware/stresswatch/data/SampleProfilesRepository.kt
@@ -10,12 +10,16 @@ import dev.mexware.stresswatch.feature.sensors.model.timeseries.TimePoint
 object SampleProfilesRepository : ProfilesRepository {
 
     data class Profile(
+        val email: String,
+        val password: String,
         val home: HomeUiState,
         val sensors: Map<SensorType, SensorDetailUiState>
     )
 
     private val profiles = listOf(
         Profile(
+            email = "ana@example.com",
+            password = "ana123",
             home = HomeUiState(
                 name = "Ana",
                 gender = Gender.FEMALE,
@@ -78,6 +82,8 @@ object SampleProfilesRepository : ProfilesRepository {
             )
         ),
         Profile(
+            email = "luis@example.com",
+            password = "luis123",
             home = HomeUiState(
                 name = "Luis",
                 gender = Gender.MALE,
@@ -140,6 +146,8 @@ object SampleProfilesRepository : ProfilesRepository {
             )
         ),
         Profile(
+            email = "carla@example.com",
+            password = "carla123",
             home = HomeUiState(
                 name = "Carla",
                 gender = Gender.FEMALE,
@@ -207,6 +215,16 @@ object SampleProfilesRepository : ProfilesRepository {
 
     override fun selectProfile(index: Int) {
         currentIndex = index.coerceIn(profiles.indices)
+    }
+
+    override fun login(email: String, password: String): Boolean {
+        val idx = profiles.indexOfFirst { it.email == email && it.password == password }
+        return if (idx >= 0) {
+            currentIndex = idx
+            true
+        } else {
+            false
+        }
     }
 
     override fun currentHomeUiState(): HomeUiState = profiles[currentIndex].home

--- a/app/src/main/java/dev/mexware/stresswatch/feature/auth/model/LoginUiState.kt
+++ b/app/src/main/java/dev/mexware/stresswatch/feature/auth/model/LoginUiState.kt
@@ -1,7 +1,7 @@
 package dev.mexware.stresswatch.feature.auth.model
 
 data class LoginUiState(
-    val email: String = ",",
+    val email: String = "",
     val password: String = "",
     val isPasswordVisible: Boolean = false,
 

--- a/app/src/main/java/dev/mexware/stresswatch/feature/auth/view/LoginScreen.kt
+++ b/app/src/main/java/dev/mexware/stresswatch/feature/auth/view/LoginScreen.kt
@@ -125,7 +125,7 @@ fun LoginScreen(
                 // ===== BOTÓN ENTRAR (mint, pill) =====
                 PrimaryButton(
                     text = "Iniciar sesión",
-                    onClick = { navController.navigate(Screen.MainScreen.name) },
+                    onClick = { viewModel.onEvent(LoginEvent.Submit) },
                     enabled = !state.isLoading,
                     modifier = Modifier
                         .fillMaxWidth()

--- a/app/src/main/java/dev/mexware/stresswatch/feature/auth/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/dev/mexware/stresswatch/feature/auth/viewmodel/LoginViewModel.kt
@@ -1,23 +1,23 @@
 package dev.mexware.stresswatch.feature.auth.viewmodel
 
-import android.R
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import dev.mexware.stresswatch.data.ProfilesRepository
+import dev.mexware.stresswatch.data.SampleProfilesRepository
 import dev.mexware.stresswatch.feature.auth.model.LoginUiState
 import dev.mexware.stresswatch.feature.auth.model.events.LoginEvent
 
-class LoginViewModel : ViewModel() {
-
-
+class LoginViewModel(
+    private val profilesRepository: ProfilesRepository = SampleProfilesRepository
+) : ViewModel() {
 
     /**
      * Estado observable por Compose. Cada asignación a `uiState` provoca recomposición.
      */
     var uiState by mutableStateOf(LoginUiState())
         private set
-
 
     /**
      * Helper para actualizar el estado de forma inmutable y segura.
@@ -30,35 +30,51 @@ class LoginViewModel : ViewModel() {
      * Único punto de entrada desde la UI.
      * La vista emite eventos y el ViewModel decide qué hacer.
      */
-
     fun onEvent(event: LoginEvent) {
-        when(event) {
+        when (event) {
             is LoginEvent.OnEmailChanged -> setState {
-                it.copy(email =  event.value, emailError = null, loginError = null)
+                it.copy(email = event.value, emailError = null, loginError = null)
             }
-            is LoginEvent.OnPasswordChanged -> setState{
+            is LoginEvent.OnPasswordChanged -> setState {
                 it.copy(password = event.value, passwordError = null, loginError = null)
-
             }
-
-            LoginEvent.TogglePasswordVisibility -> setState{
+            LoginEvent.TogglePasswordVisibility -> setState {
                 it.copy(isPasswordVisible = !it.isPasswordVisible)
             }
-            LoginEvent.ClearError -> setState{ it.copy(loginError = null)}
+            LoginEvent.ClearError -> setState { it.copy(loginError = null) }
             LoginEvent.Submit -> submit()
-
         }
     }
+
     /**
      * Orquestación del login:
      * 1) Validar campos
-     * 2) Mostrar loading
-     * 3) Llamar backend (placeholder)
-     * 4) Actualizar estado con éxito / error
+     * 2) Intentar login contra el repositorio
+     * 3) Actualizar estado con éxito / error
      */
+    private fun submit() {
+        val email = uiState.email.trim()
+        val password = uiState.password
 
-    private fun submit(){
+        var hasError = false
+        if (email.isBlank()) {
+            setState { it.copy(emailError = "Ingresa tu correo") }
+            hasError = true
+        }
+        if (password.isBlank()) {
+            setState { it.copy(passwordError = "Ingresa tu contraseña") }
+            hasError = true
+        }
+        if (hasError) return
 
+        setState { it.copy(isLoading = true) }
+        val success = profilesRepository.login(email, password)
+        setState {
+            it.copy(
+                isLoading = false,
+                isLoggedIn = success,
+                loginError = if (success) null else "Usuario o contraseña incorrectos"
+            )
+        }
     }
-
 }

--- a/app/src/main/java/dev/mexware/stresswatch/feature/chat/viewmodel/ChatViewModel.kt
+++ b/app/src/main/java/dev/mexware/stresswatch/feature/chat/viewmodel/ChatViewModel.kt
@@ -11,6 +11,12 @@ import dev.mexware.stresswatch.feature.chat.model.events.ChatUiState
 
 class ChatViewModel : ViewModel() {
 
+    private val mentalHealthResponses = mapOf(
+        "me siento mal" to "Lamento que te sientas así. Respira profundo y recuerda que buscar ayuda profesional puede ser de gran apoyo.",
+        "estoy decaido" to "Entiendo que te sientas decaído. Intenta hacer una pausa y hablar con alguien de confianza sobre cómo te sientes.",
+        "me siento solo" to "No estás solo. Contacta a un amigo o familiar y recuerda que siempre puedes buscar ayuda profesional."
+    )
+
     var uiState by mutableStateOf(
         ChatUiState(
             messages = listOf(
@@ -46,10 +52,14 @@ class ChatViewModel : ViewModel() {
             isSending = false
         )
 
-        // (Opcional) Respuesta mock del bot
+        val responseText = mentalHealthResponses.entries
+            .firstOrNull { text.lowercase().contains(it.key) }
+            ?.value
+            ?: "¡Gracias por tu mensaje! Pronto te responderé 😊"
+
         val botMsg = ChatMessage(
             id = System.currentTimeMillis() + 1,
-            text = "¡Gracias por tu mensaje! Pronto te responderé 😊",
+            text = responseText,
             sender = Sender.BOT
         )
         uiState = uiState.copy(messages = uiState.messages + botMsg)

--- a/app/src/main/java/dev/mexware/stresswatch/feature/home/view/HomeScreen.kt
+++ b/app/src/main/java/dev/mexware/stresswatch/feature/home/view/HomeScreen.kt
@@ -14,11 +14,16 @@ import dev.mexware.stresswatch.feature.home.viewmodel.HomeViewModel
 @Composable
 fun HomeScreen(
     userName: String,                // viene desde MainScreen
-    vm: HomeViewModel = viewModel()
+    profileIndex: Int = 0,
+    vm: HomeViewModel = viewModel(),
 ) {
     // Inyecta el nombre recibido (si cambia, actualiza)
     androidx.compose.runtime.LaunchedEffect(userName) {
         if (userName.isNotBlank()) vm.setName(userName)
+    }
+    // Selecciona el perfil simulado
+    androidx.compose.runtime.LaunchedEffect(profileIndex) {
+        vm.selectProfile(profileIndex)
     }
 
     val state = vm.uiState

--- a/app/src/main/java/dev/mexware/stresswatch/feature/home/view/HomeScreen.kt
+++ b/app/src/main/java/dev/mexware/stresswatch/feature/home/view/HomeScreen.kt
@@ -13,18 +13,8 @@ import dev.mexware.stresswatch.feature.home.viewmodel.HomeViewModel
 
 @Composable
 fun HomeScreen(
-    userName: String,                // viene desde MainScreen
-    profileIndex: Int = 0,
     vm: HomeViewModel = viewModel(),
 ) {
-    // Inyecta el nombre recibido (si cambia, actualiza)
-    androidx.compose.runtime.LaunchedEffect(userName) {
-        if (userName.isNotBlank()) vm.setName(userName)
-    }
-    // Selecciona el perfil simulado
-    androidx.compose.runtime.LaunchedEffect(profileIndex) {
-        vm.selectProfile(profileIndex)
-    }
 
     val state = vm.uiState
     val background = Color(0xFF0B2D46) // azul fondo

--- a/app/src/main/java/dev/mexware/stresswatch/feature/home/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/dev/mexware/stresswatch/feature/home/viewmodel/HomeViewModel.kt
@@ -16,11 +16,6 @@ class HomeViewModel(
     var uiState by mutableStateOf(profilesRepository.currentHomeUiState())
         private set
 
-    fun selectProfile(index: Int) {
-        profilesRepository.selectProfile(index)
-        uiState = profilesRepository.currentHomeUiState()
-    }
-
     fun onEvent(e: HomeEvent) {
         when (e) {
             HomeEvent.Refresh -> { /* TODO: cargar perfil real */ }
@@ -28,8 +23,4 @@ class HomeViewModel(
         }
     }
 
-    /** Permite inyectar el nombre desde MainScreen si lo pasas por parámetro */
-    fun setName(name: String) {
-        uiState = uiState.copy(name = name)
-    }
 }

--- a/app/src/main/java/dev/mexware/stresswatch/feature/home/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/dev/mexware/stresswatch/feature/home/viewmodel/HomeViewModel.kt
@@ -4,23 +4,22 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
-import dev.mexware.stresswatch.feature.auth.model.Gender
+import dev.mexware.stresswatch.data.ProfilesRepository
+import dev.mexware.stresswatch.data.SampleProfilesRepository
 import dev.mexware.stresswatch.feature.home.model.events.HomeEvent
 import dev.mexware.stresswatch.feature.home.model.events.HomeUiState
 
-class HomeViewModel : ViewModel() {
+class HomeViewModel(
+    private val profilesRepository: ProfilesRepository = SampleProfilesRepository
+) : ViewModel() {
 
-    var uiState by mutableStateOf(
-        HomeUiState(
-            // Datos emulados (se sustituyen cuando conectes tu repo/sesión)
-            name = "Christian",
-            gender = Gender.MALE,
-            birthDate = "01/01/1998",
-            country = "México",
-            avatarId = 1
-        )
-    )
+    var uiState by mutableStateOf(profilesRepository.currentHomeUiState())
         private set
+
+    fun selectProfile(index: Int) {
+        profilesRepository.selectProfile(index)
+        uiState = profilesRepository.currentHomeUiState()
+    }
 
     fun onEvent(e: HomeEvent) {
         when (e) {

--- a/app/src/main/java/dev/mexware/stresswatch/feature/main/view/MainScreen.kt
+++ b/app/src/main/java/dev/mexware/stresswatch/feature/main/view/MainScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.navigation.NavGraph.Companion.findStartDestination
-import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -33,8 +32,8 @@ import dev.mexware.stresswatch.feature.sensors.view.detail.SensorDetailScreen
 
 @Composable
 fun MainScreen(
-    navController: NavHostController,
-    userName: String = "Christian" // pásalo desde arriba cuando lo tengas
+    userName: String = "Christian", // pásalo desde arriba cuando lo tengas
+    profileIndex: Int = 0
 ) {
     val nav = rememberNavController()
     val currentRoute = nav.currentBackStackEntryAsState().value?.destination?.route
@@ -66,7 +65,7 @@ fun MainScreen(
                 startDestination = MainDestination.HOME.route
             ) {
                 composable(MainDestination.HOME.route) {
-                    HomeScreen(userName = userName)
+                    HomeScreen(userName = userName, profileIndex = profileIndex)
                 }
                 composable(MainDestination.CHAT.route) {
                     ChatScreen()

--- a/app/src/main/java/dev/mexware/stresswatch/feature/main/view/MainScreen.kt
+++ b/app/src/main/java/dev/mexware/stresswatch/feature/main/view/MainScreen.kt
@@ -31,10 +31,7 @@ import dev.mexware.stresswatch.feature.sensors.model.SensorType
 import dev.mexware.stresswatch.feature.sensors.view.detail.SensorDetailScreen
 
 @Composable
-fun MainScreen(
-    userName: String = "Christian", // pásalo desde arriba cuando lo tengas
-    profileIndex: Int = 0
-) {
+fun MainScreen() {
     val nav = rememberNavController()
     val currentRoute = nav.currentBackStackEntryAsState().value?.destination?.route
 
@@ -65,7 +62,7 @@ fun MainScreen(
                 startDestination = MainDestination.HOME.route
             ) {
                 composable(MainDestination.HOME.route) {
-                    HomeScreen(userName = userName, profileIndex = profileIndex)
+                    HomeScreen()
                 }
                 composable(MainDestination.CHAT.route) {
                     ChatScreen()

--- a/app/src/main/java/dev/mexware/stresswatch/feature/sensors/view/components/SensorLineChart.kt
+++ b/app/src/main/java/dev/mexware/stresswatch/feature/sensors/view/components/SensorLineChart.kt
@@ -1,16 +1,20 @@
 package dev.mexware.stresswatch.feature.sensors.view.components
 
+import android.graphics.Paint
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import dev.mexware.stresswatch.feature.sensors.model.timeseries.TimePoint
 import kotlin.math.max
 
@@ -23,18 +27,19 @@ fun SensorLineChart(
     points: List<TimePoint>,
     modifier: Modifier = Modifier
         .fillMaxWidth()
-        .height(180.dp),
+        .height(200.dp),
     bg: Color = Color(0xFF0E3A5A),
     line: Color = Color(0xFF5FBCA7),
     grid: Color = Color(0x33FFFFFF)
 ) {
     Canvas(modifier = modifier.background(bg).padding(horizontal = 8.dp, vertical = 6.dp)) {
         val w = size.width
-        val h = size.height
+        val labelSpace = 20.dp.toPx()
+        val chartH = size.height - labelSpace
 
         // Grid horizontal (4 líneas)
         val rows = 4
-        val stepY = h / rows
+        val stepY = chartH / rows
         repeat(rows + 1) { i ->
             val y = i * stepY
             drawLine(color = grid, start = Offset(0f, y), end = Offset(w, y), strokeWidth = 1f)
@@ -43,21 +48,54 @@ fun SensorLineChart(
         if (points.isEmpty()) return@Canvas
 
         val stepX = if (points.size <= 1) w else w / (points.size - 1)
+
+        // Grid vertical
+        repeat(points.size) { i ->
+            val x = i * stepX
+            drawLine(color = grid, start = Offset(x, 0f), end = Offset(x, chartH), strokeWidth = 1f)
+        }
+
         val maxV = max(points.maxOf { it.value }, 1f)
 
         val path = Path()
+        val fill = Path()
         points.forEachIndexed { i, p ->
             val x = i * stepX
-            val y = h - (p.value / maxV) * h
-            if (i == 0) path.moveTo(x, y) else path.lineTo(x, y)
+            val y = chartH - (p.value / maxV) * chartH
+            if (i == 0) {
+                path.moveTo(x, y)
+                fill.moveTo(x, chartH)
+                fill.lineTo(x, y)
+            } else {
+                path.lineTo(x, y)
+                fill.lineTo(x, y)
+            }
         }
-        drawPath(path, color = line)
+        fill.lineTo((points.size - 1) * stepX, chartH)
+        fill.close()
+        drawPath(
+            fill,
+            brush = Brush.verticalGradient(listOf(line.copy(alpha = 0.4f), Color.Transparent))
+        )
+        drawPath(path, color = line, strokeWidth = 4f)
 
-        // Puntos
+        val labelPaint = Paint().apply {
+            color = Color.White.toArgb()
+            textAlign = Paint.Align.CENTER
+            textSize = 12.sp.toPx()
+        }
+        val valuePaint = Paint().apply {
+            color = Color.White.toArgb()
+            textAlign = Paint.Align.CENTER
+            textSize = 10.sp.toPx()
+        }
+
         points.forEachIndexed { i, p ->
             val x = i * stepX
-            val y = h - (p.value / maxV) * h
+            val y = chartH - (p.value / maxV) * chartH
             drawCircle(color = line, radius = 4.dp.toPx(), center = Offset(x, y))
+            drawContext.canvas.nativeCanvas.drawText(p.label, x, size.height - 4.dp.toPx(), labelPaint)
+            drawContext.canvas.nativeCanvas.drawText(p.value.toInt().toString(), x, y - 8.dp.toPx(), valuePaint)
         }
     }
 }

--- a/app/src/main/java/dev/mexware/stresswatch/feature/sensors/view/detail/SensorDatailScreen.kt
+++ b/app/src/main/java/dev/mexware/stresswatch/feature/sensors/view/detail/SensorDatailScreen.kt
@@ -26,6 +26,9 @@ fun SensorDetailScreen(
     LaunchedEffect(type) { vm.load(type) }
     val state = vm.uiState ?: return
 
+    val avg = state.points.map { it.value }.average().toInt()
+    val max = state.points.maxOf { it.value }.toInt()
+
     Surface(color = bg, modifier = Modifier.fillMaxSize()) {
         Column(
             modifier = Modifier
@@ -49,7 +52,18 @@ fun SensorDetailScreen(
             Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
                 MetricStat(
                     title = state.summary.totalLabel,
-                    value = state.summary.totalValue
+                    value = state.summary.totalValue,
+                    modifier = Modifier.weight(1f)
+                )
+                MetricStat(
+                    title = "Promedio",
+                    value = "${avg}%",
+                    modifier = Modifier.weight(1f)
+                )
+                MetricStat(
+                    title = "Máximo",
+                    value = "${max}%",
+                    modifier = Modifier.weight(1f)
                 )
             }
 

--- a/app/src/main/java/dev/mexware/stresswatch/feature/sensors/viewmodel/SensorDetailViewModel.kt
+++ b/app/src/main/java/dev/mexware/stresswatch/feature/sensors/viewmodel/SensorDetailViewModel.kt
@@ -4,57 +4,21 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import dev.mexware.stresswatch.data.ProfilesRepository
+import dev.mexware.stresswatch.data.SampleProfilesRepository
 import dev.mexware.stresswatch.feature.sensors.model.SensorType
 import dev.mexware.stresswatch.feature.sensors.model.events.SensorDetailEvent
 import dev.mexware.stresswatch.feature.sensors.model.events.SensorDetailUiState
-import dev.mexware.stresswatch.feature.sensors.model.timeseries.Summary
-import dev.mexware.stresswatch.feature.sensors.model.timeseries.TimePoint
-import kotlin.random.Random
 
-class SensorDetailViewModel : ViewModel() {
+class SensorDetailViewModel(
+    private val profilesRepository: ProfilesRepository = SampleProfilesRepository
+) : ViewModel() {
 
     var uiState by mutableStateOf<SensorDetailUiState?>(null)
         private set
 
     fun load(type: SensorType) {
-        // Datos mock: 7 puntos (semana)
-        val labels = listOf("L", "M", "X", "J", "V", "S", "D")
-        val bounds = when (type) {
-            SensorType.SLEEP -> 60..95      // %
-            SensorType.STRESS -> 15..85     // índice %
-            SensorType.MOOD -> 40..90       // % “ánimo”
-        }
-        val pts = labels.map { l ->
-            val v = Random.nextInt(bounds.first, bounds.last).toFloat()
-            TimePoint(label = l, value = v)
-        }
-
-        val current = pts.last().value
-        val summary = when (type) {
-            SensorType.SLEEP -> Summary(
-                totalLabel = "Sueño total",
-                totalValue = "${current.toInt()}%",
-                note = if (current >= 75f) "Buen descanso esta semana"
-                else "Intenta mejorar tu rutina nocturna"
-            )
-            SensorType.STRESS -> Summary(
-                totalLabel = "Estrés actual",
-                totalValue = "${current.toInt()}%",
-                note = when {
-                    current < 40f -> "Estrés bajo"
-                    current < 70f -> "Estrés moderado"
-                    else -> "Estrés alto"
-                }
-            )
-            SensorType.MOOD -> Summary(
-                totalLabel = "Ánimo actual",
-                totalValue = "${current.toInt()}%",
-                note = if (current >= 60f) "Mejor que la semana pasada"
-                else "Podrías intentar una sesión de respiración"
-            )
-        }
-
-        uiState = SensorDetailUiState(type = type, points = pts, summary = summary)
+        uiState = profilesRepository.sensorData(type)
     }
 
     fun onEvent(e: SensorDetailEvent) {

--- a/app/src/main/java/dev/mexware/stresswatch/navigation/NavGraph.kt
+++ b/app/src/main/java/dev/mexware/stresswatch/navigation/NavGraph.kt
@@ -19,6 +19,6 @@ fun NavGraph(){
         composable(route = Screen.LogoScreen.name){ LogoScreen(navControler) }
         composable(route = Screen.LoginScreen.name) { LoginScreen(navControler) }
         composable(route = Screen.RegisterScreen.name) { RegisterScreen(navControler) }
-        composable(route = Screen.MainScreen.name) { MainScreen(navControler) }
+        composable(route = Screen.MainScreen.name) { MainScreen() }
     }
 }

--- a/app/src/main/java/dev/mexware/stresswatch/navigation/NavGraph.kt
+++ b/app/src/main/java/dev/mexware/stresswatch/navigation/NavGraph.kt
@@ -17,7 +17,12 @@ fun NavGraph(){
 
     NavHost(navControler, startDestination =  "logo"){
         composable(route = Screen.LogoScreen.name){ LogoScreen(navControler) }
-        composable(route = Screen.LoginScreen.name) { LoginScreen(navControler) }
+        composable(route = Screen.LoginScreen.name) {
+            LoginScreen(
+                navController = navControler,
+                navigateToHome = { navControler.navigate(Screen.MainScreen.name) }
+            )
+        }
         composable(route = Screen.RegisterScreen.name) { RegisterScreen(navControler) }
         composable(route = Screen.MainScreen.name) { MainScreen() }
     }


### PR DESCRIPTION
## Summary
- add ProfilesRepository interface for easier dependency injection
- make SampleProfilesRepository implement ProfilesRepository
- remove unused navController parameter from MainScreen and adjust NavGraph

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c96497e248333bce4f2ec52ccde42